### PR TITLE
refactor: update Next.js parameter types and revert dependencies

### DIFF
--- a/app/(home)/learn/[level]/[...doc_path]/page.tsx
+++ b/app/(home)/learn/[level]/[...doc_path]/page.tsx
@@ -1,3 +1,8 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import type { ReactNode } from "react";
 import NextIcon from "@/assets/svg/next.svg";
 import PrevIcon from "@/assets/svg/prev.svg";
 import { type DocPathParams, Levels } from "@/types";
@@ -5,11 +10,6 @@ import { isDev } from "@/utils/is-dev";
 import { type FileItem, listAllDocs } from "@/utils/list-docs";
 import { loadMDX } from "@/utils/load-mdx";
 import { timeOut } from "@/utils/time-out";
-import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import Link from "next/link";
-import { redirect } from "next/navigation";
-import type { ReactNode } from "react";
 import { MDContentWrapper } from "../_components/markdown-wrapper";
 import { Toc } from "../_components/toc";
 
@@ -38,7 +38,7 @@ export async function generateMetadata(props: {
 }
 
 export async function generateStaticParams(props: {
-	params: Awaited<PageProps<'/learn/[level]/[...doc_path]'>['params']>;
+	params: Promise<DocPathParams>;
 }) {
 	const { level } = await props.params;
 	const docs = await listAllDocs(level);
@@ -92,7 +92,10 @@ export default async function Page(props: { params: Promise<DocPathParams> }) {
 	const NavButton = ({
 		children,
 		href,
-	}: { children: ReactNode; href: string }) => (
+	}: {
+		children: ReactNode;
+		href: string;
+	}) => (
 		<Link
 			prefetch
 			href={href}

--- a/app/(home)/learn/[level]/layout.tsx
+++ b/app/(home)/learn/[level]/layout.tsx
@@ -1,4 +1,4 @@
-import { Levels } from "@/types";
+import { type DocPathParams, Levels } from "@/types";
 import { DocsCategory } from "./_components/category";
 import { DocsLayout } from "./_components/docs-layout";
 
@@ -13,7 +13,7 @@ export default async function Layout({
 	params,
 }: {
 	children: React.ReactNode;
-	params: LayoutProps<'/learn/[level]'>['params'];
+	params: Promise<DocPathParams>;
 }) {
 	const { level } = await params;
 

--- a/app/(home)/tools/[[...tool]]/layout.tsx
+++ b/app/(home)/tools/[[...tool]]/layout.tsx
@@ -1,7 +1,7 @@
-import { type ToolName, toolsNames } from "@/types/tools";
 import clsx from "clsx";
-import { getTranslations } from "next-intl/server";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { type ToolName, toolsNames } from "@/types/tools";
 
 const list: {
 	href: string;
@@ -73,7 +73,10 @@ export async function generateStaticParams() {
 export default async function Layout({
 	children,
 	params,
-}: LayoutProps<'/tools/[[...tool]]'>) {
+}: {
+	children: React.ReactNode;
+	params: Promise<{ tool: string[] }>;
+}) {
 	const tTools = await getTranslations("Tools");
 	const tool = ((await params).tool || [])[0] as ToolName;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
 				"@keystone-6/fields-document": "^9.1.1",
 				"@mdx-js/loader": "^3.1.0",
 				"@mdx-js/react": "^3.1.0",
-				"@next/bundle-analyzer": "15.5.6",
-				"@next/mdx": "15.5.6",
-				"@next/third-parties": "15.5.6",
+				"@next/bundle-analyzer": "15.4.4",
+				"@next/mdx": "15.4.4",
+				"@next/third-parties": "15.4.4",
 				"@prisma/client": "^5.22.0",
 				"@svgr/webpack": "^8.1.0",
 				"@types/mdx": "^2.0.13",
@@ -42,7 +42,7 @@
 				"js-cookie": "^3.0.5",
 				"jszip": "^3.10.1",
 				"marked": "^15.0.3",
-				"next": "15.5.6",
+				"next": "15.4.4",
 				"next-auth": "^5.0.0-beta.25",
 				"next-cache-toolbar": "^0.2.1",
 				"next-intl": "^3.26.0",
@@ -6007,24 +6007,24 @@
 			}
 		},
 		"node_modules/@next/bundle-analyzer": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.5.6.tgz",
-			"integrity": "sha512-IHeyk2s9/fVDAGDLNbBkCSG8XBabhuMajiaJggjsg4GyFIswh78DzLo5Nl5th8QTs3U/teYeczvfeV9w1Tx3qA==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.4.4.tgz",
+			"integrity": "sha512-/jDIIgLhzErHv36+DBymfMSMrmBq8EPfTGwBCjfz9DZFN9sdUC+4dJcu9OuDKpna+EuznAJnVTrMLd9NSBFVwg==",
 			"license": "MIT",
 			"dependencies": {
 				"webpack-bundle-analyzer": "4.10.1"
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.6.tgz",
-			"integrity": "sha512-3qBGRW+sCGzgbpc5TS1a0p7eNxnOarGVQhZxfvTdnV0gFI61lX7QNtQ4V1TSREctXzYn5NetbUsLvyqwLFJM6Q==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.4.tgz",
+			"integrity": "sha512-SJKOOkULKENyHSYXE5+KiFU6itcIb6wSBjgM92meK0HVKpo94dNOLZVdLLuS7/BxImROkGoPsjR4EnuDucqiiA==",
 			"license": "MIT"
 		},
 		"node_modules/@next/mdx": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.6.tgz",
-			"integrity": "sha512-lyzXcnZWPjYxbkz/5tv1bRlCOjKYX1lFg3LIuoIf9ERTOUBDzkCvUnWjtRsmFRxKv1/6uwpLVQvrJDd54gVDBw==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.4.4.tgz",
+			"integrity": "sha512-DB64O/+wlcqr0XrATgGLTk3FqxdOgC035iC4wDlmG2QugNVq7godC6bLhVdNbo9uW7ib0tmgESXcG3JV7l9HiA==",
 			"license": "MIT",
 			"dependencies": {
 				"source-map": "^0.7.0"
@@ -6052,9 +6052,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.6.tgz",
-			"integrity": "sha512-ES3nRz7N+L5Umz4KoGfZ4XX6gwHplwPhioVRc25+QNsDa7RtUF/z8wJcbuQ2Tffm5RZwuN2A063eapoJ1u4nPg==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.4.tgz",
+			"integrity": "sha512-eVG55dnGwfUuG+TtnUCt+mEJ+8TGgul6nHEvdb8HEH7dmJIFYOCApAaFrIrxwtEq2Cdf+0m5sG1Np8cNpw9EAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6068,9 +6068,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.6.tgz",
-			"integrity": "sha512-JIGcytAyk9LQp2/nuVZPAtj8uaJ/zZhsKOASTjxDug0SPU9LAM3wy6nPU735M1OqacR4U20LHVF5v5Wnl9ptTA==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.4.tgz",
+			"integrity": "sha512-zqG+/8apsu49CltEj4NAmCGZvHcZbOOOsNoTVeIXphYWIbE4l6A/vuQHyqll0flU2o3dmYCXsBW5FmbrGDgljQ==",
 			"cpu": [
 				"x64"
 			],
@@ -6084,9 +6084,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.6.tgz",
-			"integrity": "sha512-qvz4SVKQ0P3/Im9zcS2RmfFL/UCQnsJKJwQSkissbngnB/12c6bZTCB0gHTexz1s6d/mD0+egPKXAIRFVS7hQg==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.4.tgz",
+			"integrity": "sha512-LRD4l2lq4R+2QCHBQVC0wjxxkLlALGJCwigaJ5FSRSqnje+MRKHljQNZgDCaKUZQzO/TXxlmUdkZP/X3KNGZaw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6100,9 +6100,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.6.tgz",
-			"integrity": "sha512-FsbGVw3SJz1hZlvnWD+T6GFgV9/NYDeLTNQB2MXoPN5u9VA9OEDy6fJEfePfsUKAhJufFbZLgp0cPxMuV6SV0w==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.4.tgz",
+			"integrity": "sha512-LsGUCTvuZ0690fFWerA4lnQvjkYg9gHo12A3wiPUR4kCxbx/d+SlwmonuTH2SWZI+RVGA9VL3N0S03WTYv6bYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6116,9 +6116,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.6.tgz",
-			"integrity": "sha512-3QnHGFWlnvAgyxFxt2Ny8PTpXtQD7kVEeaFat5oPAHHI192WKYB+VIKZijtHLGdBBvc16tiAkPTDmQNOQ0dyrA==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.4.tgz",
+			"integrity": "sha512-aOy5yNRpLL3wNiJVkFYl6w22hdREERNjvegE6vvtix8LHRdsTHhWTpgvcYdCK7AIDCQW5ATmzr9XkPHvSoAnvg==",
 			"cpu": [
 				"x64"
 			],
@@ -6132,9 +6132,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.6.tgz",
-			"integrity": "sha512-OsGX148sL+TqMK9YFaPFPoIaJKbFJJxFzkXZljIgA9hjMjdruKht6xDCEv1HLtlLNfkx3c5w2GLKhj7veBQizQ==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.4.tgz",
+			"integrity": "sha512-FL7OAn4UkR8hKQRGBmlHiHinzOb07tsfARdGh7v0Z0jEJ3sz8/7L5bR23ble9E6DZMabSStqlATHlSxv1fuzAg==",
 			"cpu": [
 				"x64"
 			],
@@ -6148,9 +6148,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.6.tgz",
-			"integrity": "sha512-ONOMrqWxdzXDJNh2n60H6gGyKed42Ieu6UTVPZteXpuKbLZTH4G4eBMsr5qWgOBA+s7F+uB4OJbZnrkEDnZ5Fg==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.4.tgz",
+			"integrity": "sha512-eEdNW/TXwjYhOulQh0pffTMMItWVwKCQpbziSBmgBNFZIIRn2GTXrhrewevs8wP8KXWYMx8Z+mNU0X+AfvtrRg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6164,9 +6164,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.6.tgz",
-			"integrity": "sha512-pxK4VIjFRx1MY92UycLOOw7dTdvccWsNETQ0kDHkBlcFH1GrTLUjSiHU1ohrznnux6TqRHgv5oflhfIWZwVROQ==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.4.tgz",
+			"integrity": "sha512-SE5pYNbn/xZKMy1RE3pAs+4xD32OI4rY6mzJa4XUkp/ItZY+OMjIgilskmErt8ls/fVJ+Ihopi2QIeW6O3TrMw==",
 			"cpu": [
 				"x64"
 			],
@@ -6180,9 +6180,9 @@
 			}
 		},
 		"node_modules/@next/third-parties": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.5.6.tgz",
-			"integrity": "sha512-B1BLvEi7edGERNN0njxpiqbqkp3zAZ69eJ5C0vwj/XINRzcC25b9MCqxbSHq094d306H65UnlhEkBv+a8c74iA==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.4.4.tgz",
+			"integrity": "sha512-0GIEDSxfl9hTU4Ne1TVr/lZUS1wGhDPB4gt6TNvLBA3Fioum+qZRoPt3fiOW9hHQynyLsojglRDaB97T92h0Og==",
 			"license": "MIT",
 			"dependencies": {
 				"third-party-capital": "1.0.20"
@@ -16854,12 +16854,12 @@
 			"peer": true
 		},
 		"node_modules/next": {
-			"version": "15.5.6",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.5.6.tgz",
-			"integrity": "sha512-zTxsnI3LQo3c9HSdSf91O1jMNsEzIXDShXd4wVdg9y5shwLqBXi4ZtUUJyB86KGVSJLZx0PFONvO54aheGX8QQ==",
+			"version": "15.4.4",
+			"resolved": "https://registry.npmjs.org/next/-/next-15.4.4.tgz",
+			"integrity": "sha512-kNcubvJjOL9yUOfwtZF3HfDhuhp+kVD+FM2A6Tyua1eI/xfmY4r/8ZS913MMz+oWKDlbps/dQOWdDricuIkXLw==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.5.6",
+				"@next/env": "15.4.4",
 				"@swc/helpers": "0.5.15",
 				"caniuse-lite": "^1.0.30001579",
 				"postcss": "8.4.31",
@@ -16872,14 +16872,14 @@
 				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.5.6",
-				"@next/swc-darwin-x64": "15.5.6",
-				"@next/swc-linux-arm64-gnu": "15.5.6",
-				"@next/swc-linux-arm64-musl": "15.5.6",
-				"@next/swc-linux-x64-gnu": "15.5.6",
-				"@next/swc-linux-x64-musl": "15.5.6",
-				"@next/swc-win32-arm64-msvc": "15.5.6",
-				"@next/swc-win32-x64-msvc": "15.5.6",
+				"@next/swc-darwin-arm64": "15.4.4",
+				"@next/swc-darwin-x64": "15.4.4",
+				"@next/swc-linux-arm64-gnu": "15.4.4",
+				"@next/swc-linux-arm64-musl": "15.4.4",
+				"@next/swc-linux-x64-gnu": "15.4.4",
+				"@next/swc-linux-x64-musl": "15.4.4",
+				"@next/swc-win32-arm64-msvc": "15.4.4",
+				"@next/swc-win32-x64-msvc": "15.4.4",
 				"sharp": "^0.34.3"
 			},
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
 		"@keystone-6/fields-document": "^9.1.1",
 		"@mdx-js/loader": "^3.1.0",
 		"@mdx-js/react": "^3.1.0",
-		"@next/bundle-analyzer": "15.5.6",
-		"@next/mdx": "15.5.6",
-		"@next/third-parties": "15.5.6",
+		"@next/bundle-analyzer": "15.4.4",
+		"@next/mdx": "15.4.4",
+		"@next/third-parties": "15.4.4",
 		"@prisma/client": "^5.22.0",
 		"@svgr/webpack": "^8.1.0",
 		"@types/mdx": "^2.0.13",
@@ -59,7 +59,7 @@
 		"js-cookie": "^3.0.5",
 		"jszip": "^3.10.1",
 		"marked": "^15.0.3",
-		"next": "15.5.6",
+		"next": "15.4.4",
 		"next-auth": "^5.0.0-beta.25",
 		"next-cache-toolbar": "^0.2.1",
 		"next-intl": "^3.26.0",
@@ -149,6 +149,6 @@
 	"overrides": {
 		"react": "19.1.0",
 		"react-dom": "19.1.0",
-		"next": "15.5.6"
+		"next": "15.4.4"
 	}
 }


### PR DESCRIPTION
## Summary
- Update Next.js parameter types to use Promise<DocPathParams> for better async handling
- Revert Next.js dependencies from 15.5.6 to 15.4.4 to resolve compatibility issues
- Reorganize imports and improve type consistency in layout components

## Changes Made
- Updated page.tsx: Fixed import order and updated generateStaticParams type
- Updated layout.tsx: Changed parameter type to Promise<DocPathParams>
- Updated tools layout: Fixed import order and updated parameter type
- Reverted package.json and package-lock.json to Next.js 15.4.4

## Test plan
- [ ] Run `npm run dev` to verify development server works
- [ ] Run `npm run build` to verify production build succeeds
- [ ] Test navigation between learning pages
- [ ] Verify tools section functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)